### PR TITLE
Test encryption & tune for performance

### DIFF
--- a/encryption.go
+++ b/encryption.go
@@ -19,6 +19,17 @@ type Keypair struct {
 	Kid        string
 }
 
+func NewKeypair(key *rsa.PrivateKey) (*Keypair, error) {
+	if key == nil {
+		return RandomKeypair(1024)
+	}
+
+	return &Keypair{
+		PrivateKey: key,
+		PublicKey:  &key.PublicKey,
+	}, nil
+}
+
 func RandomKeypair(size int) (*Keypair, error) {
 	key, err := rsa.GenerateKey(rand.Reader, size)
 	if err != nil {
@@ -73,7 +84,7 @@ func (k *Keypair) JWKS() (string, error) {
 }
 
 func (k *Keypair) SignJWT(claims jwt.Claims) (string, error) {
-	token := jwt.NewWithClaims(jwt.GetSigningMethod("RS256"), claims)
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
 
 	kid, err := k.KeyID()
 	if err != nil {

--- a/encryption_test.go
+++ b/encryption_test.go
@@ -1,0 +1,69 @@
+package mockoidc_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/oauth2-proxy/mockoidc/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	audience = "mockoidc"
+	issuer   = "https://github.com/oauth2-proxy/mockoidc/"
+)
+
+var (
+	standardClaims = &jwt.StandardClaims{
+		Audience:  audience,
+		ExpiresAt: time.Now().Add(time.Duration(1) * time.Hour).Unix(),
+		Id:        "0123456789abcdef",
+		IssuedAt:  time.Now().Unix(),
+		Issuer:    issuer,
+		NotBefore: 0,
+		Subject:   "123456789",
+	}
+)
+
+func TestSignJWTVerifyJWT(t *testing.T) {
+	for _, size := range []int{512, 1024, 2048, 4096} {
+		t.Run(fmt.Sprintf("%d", size), func(t *testing.T) {
+			alice, err := mockoidc.RandomKeypair(size)
+			assert.NoError(t, err)
+			bob, err := mockoidc.RandomKeypair(size)
+			assert.NoError(t, err)
+
+			assert.NotEqual(t, alice.PrivateKey.N, bob.PrivateKey.N)
+
+			tokenStr, err := alice.SignJWT(standardClaims)
+			assert.NoError(t, err)
+
+			_, err = bob.VerifyJWT(tokenStr)
+			assert.Error(t, err)
+
+			token, err := alice.VerifyJWT(tokenStr)
+			assert.NoError(t, err)
+			assert.True(t, token.Valid)
+
+			claims, ok := token.Claims.(jwt.MapClaims)
+			assert.True(t, ok)
+			assert.Equal(t, audience, claims["aud"])
+			assert.Equal(t, issuer, claims["iss"])
+
+			alice.Kid = "WRONG"
+			_, err = alice.VerifyJWT(tokenStr)
+			assert.Error(t, err)
+
+			const customKid = "USER_DEFINED"
+			bob.Kid = customKid
+			kidTokenStr, err := bob.SignJWT(standardClaims)
+			assert.NoError(t, err)
+
+			kidToken, err := bob.VerifyJWT(kidTokenStr)
+			assert.NoError(t, err)
+			assert.Equal(t, customKid, kidToken.Header["kid"])
+		})
+	}
+}


### PR DESCRIPTION
I realized `rsa.GenerateKey` is very slow, especially for larger sizes.

I added an argument to `mockoidc.NewServer` to provide a preexisting `*rsa.PrivateKey` so people spinning up and tearing down a lot of these servers can potentially use the same RSA key.