### PR TITLE
Minimize Randomness & allow tester set values

### DIFF
--- a/encryption.go
+++ b/encryption.go
@@ -7,11 +7,40 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 
 	"github.com/dgrijalva/jwt-go"
 	"gopkg.in/square/go-jose.v2"
 )
+
+const DefaultPrivateKey = `-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAtI1Jf2zmfwLzpAjVarORtjKtmCHQtgNxqWDdVNVagCb092tL
+rBRv0fTfHIJG+YpmmTrRN5yKax9bI3oSYNZJufAN3gu4TIrlLoFv6npC+k3rK+sb
+iD2m0iz9duxe7uVSEHCJlcMas86Wa+VGBlAZQpnqh2TlaHXhyVbm+gHFGU0u26Pg
+v5Esw2DEwRh0l7nK1ygg8dL/NNdtnaxTYhWAVPo4Vqcl2a9n+bs65maK02IgBLpa
+LRUtjfjSIV17YBzlr6ekr7GwkDTD79d3Uc2GSSGzWqKlFtXmM9cFkfGGOYcaQLoE
+LbkxaGfLmKI53HIxXUK28JjVCxITGl60u/Z5bQIDAQABAoIBADzUXS7RQdcI540c
+bMrGNRFtgY7/1ZF9F445VFiAiT0j4uR5AcW4HPRfy8uPGNp6BpcZeeOCmh/9MHeD
+aS23BJ/ggMuOp0kigpRoh4w4JNiv58ukKmJ8YvfssHigqltSZ5OiVrheQ2DQ+Vzg
+ofb+hYQq1xlGpQPMs4ViAe+5KO6cwXYTL3j7PXAtE34Cl6JW36dd2U4G7EeEK8in
+q+zCg6U0mtyudz+6YicOLXaNKmJaSUn8pWuWqUd14mpqgo54l46mMx9d/HmG45jp
+MUam7qVYQ9ixtRp3vCUp5k4aSgigX0dn8pv3TGpSyq/t6g93DtMlXDY9rUjgQ3w5
+Y8L+kAECgYEAz0sCr++a+rXHzLDdRpsI5nzYqpwB8GOJKTADrkil/F1PfQ3SAqGt
+b4ioQNO054WQYHzZFryh4joTiOkmlgjM0k8eRJ4442ayJe6vm/apxWGkAiS0szoo
+yUpH4OqVwUaDjA7yF3PBuMc1Ub65EQU9mcsEBVdlNO/hfF/1C2LupPECgYEA3vnC
+JYp1MYy7zUSov70UTP/P01J5kIFYzY4VHRI4C0xZG4w/wjgsnYbGT1n9r14W/i7E
+hEV1R0SxmbnrbfSt31niZfCfzl+jq7v/q0+6gm51y1sm68jdFSgwxcRKbD41jP3B
+UNrfQhJdpB2FbSNAHQSng0XLVFfhDGFnzn277D0CgYAZ5glD6e+2+xcnX8GFnMET
+6u03A57KZeUxHCqZj8INMatIuH1QjtqYYL6Euu6TLoDHTVHiIVcoaJEgPeDwRdEx
+RWlGsW3yG1aOnq+aEMtNOdG/4s4gxldqLrmkRCrJpwGwcf2VKIU/jMQAno+IrNrx
+aAfskuq2HnJRk7uN3KJsQQKBgQC0YCcGZ3NWmhpye1Bni3WYtHhS4y0kEP7dikra
+MZrUyPZsqpAJdZfh9t0F5C6sZtkC1qJyvh2ZgaCKUzR4xq7BN91Fydn9ALFOg87X
+rq+aQ/FWiG573wm5y8FoutnZppl7bOutlOF2eZT25krBdvqufs1kDFnn6Q9NDJ8F
+FAGpoQKBgDMXVHVXNCJWO13/rwakBe4a9W/lbKuVX27wgCBcu3i/lGYjggm8GPka
+Wk14b+reOmP3tZyZxDyX2zFyjkJpu2SWd5TlAL59vP3dzx+uyj6boWCCZHxzepli
+5eHXOeVW+S+gwlCAF0U0n/XJ7Qhv0/SQnxSqT+D6V1+KbbeXnO7w
+-----END RSA PRIVATE KEY-----`
 
 type Keypair struct {
 	PrivateKey *rsa.PrivateKey
@@ -21,7 +50,7 @@ type Keypair struct {
 
 func NewKeypair(key *rsa.PrivateKey) (*Keypair, error) {
 	if key == nil {
-		return RandomKeypair(1024)
+		return DefaultKeypair()
 	}
 
 	return &Keypair{
@@ -32,6 +61,19 @@ func NewKeypair(key *rsa.PrivateKey) (*Keypair, error) {
 
 func RandomKeypair(size int) (*Keypair, error) {
 	key, err := rsa.GenerateKey(rand.Reader, size)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Keypair{
+		PrivateKey: key,
+		PublicKey:  &key.PublicKey,
+	}, nil
+}
+
+func DefaultKeypair() (*Keypair, error) {
+	block, _ := pem.Decode([]byte(DefaultPrivateKey))
+	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +114,7 @@ func (k *Keypair) JWKS() ([]byte, error) {
 	jwk := jose.JSONWebKey{
 		Use:       "sig",
 		Algorithm: string(jose.RS256),
-		Key:       k.PrivateKey,
+		Key:       k.PublicKey,
 		KeyID:     kid,
 	}
 	jwks := &jose.JSONWebKeySet{

--- a/mockoidc.go
+++ b/mockoidc.go
@@ -153,15 +153,24 @@ func (m *MockOIDC) Issuer() string {
 
 // QueueUser allows adding mock User objects to the authentication queue.
 // Calls to the `authorization_endpoint` will pop these mock User objects
-// of the queue and create a session with them.
+// off the queue and create a session with them.
 func (m *MockOIDC) QueueUser(user *User) {
 	m.UserQueue.Push(user)
 }
 
+// QueueCode allows adding mock code strings to the authentication queue.
+// Calls to the `authorization_endpoint` will pop these code strings
+// off the queue and create a session with them and return them as the
+// code parameter in the response.
+func (m *MockOIDC) QueueCode(code string) {
+	m.SessionStore.CodeQueue.Push(code)
+}
+
 // FastForward moves the MockOIDC's internal view of time forward.
 // Use this to test token expirations in your tests.
-func (m *MockOIDC) FastForward(d time.Duration) {
+func (m *MockOIDC) FastForward(d time.Duration) time.Duration {
 	m.fastForward = m.fastForward + d
+	return m.fastForward
 }
 
 // Now is what MockOIDC thinks time.Now is

--- a/queue.go
+++ b/queue.go
@@ -1,0 +1,65 @@
+package mockoidc
+
+import "sync"
+
+// UserQueue manages the queue of Users returned for each
+// call to the authorize endpoint
+type UserQueue struct {
+	sync.Mutex
+	Queue []*User
+}
+
+// CodeQueue manages the queue of codes returned for each
+// call to the authorize endpoint
+type CodeQueue struct {
+	sync.Mutex
+	Queue []string
+}
+
+// Push adds a User to the Queue to be set in subsequent calls to the
+// `authorization_endpoint`
+func (q *UserQueue) Push(user *User) {
+	q.Lock()
+	defer q.Unlock()
+	q.Queue = append(q.Queue, user)
+}
+
+// Pop a User from the Queue. If empty, return `DefaultUser()`
+func (q *UserQueue) Pop() *User {
+	q.Lock()
+	defer q.Unlock()
+
+	if len(q.Queue) == 0 {
+		return DefaultUser()
+	}
+
+	var user *User
+	user, q.Queue = q.Queue[0], q.Queue[1:]
+	return user
+}
+
+// Push adds a code to the Queue to be returned by subsequent
+// `authorization_endpoint` calls as the code
+func (q *CodeQueue) Push(code string) {
+	q.Lock()
+	defer q.Unlock()
+	q.Queue = append(q.Queue, code)
+}
+
+// Pop a `code` from the Queue. If empty, return a random code
+func (q *CodeQueue) Pop() (string, error) {
+	q.Lock()
+	defer q.Unlock()
+
+	if len(q.Queue) == 0 {
+		code, err := randomNonce(24)
+		if err != nil {
+			return "", err
+		}
+		return code, nil
+	}
+
+	var code string
+	code, q.Queue = q.Queue[0], q.Queue[1:]
+	return code, nil
+}

--- a/session.go
+++ b/session.go
@@ -19,19 +19,21 @@ type Session struct {
 
 // SessionStore manages our Session objects
 type SessionStore struct {
-	Store map[string]*Session
+	Store     map[string]*Session
+	CodeQueue *CodeQueue
 }
 
 // NewSessionStore initializes the SessionStore for this server
 func NewSessionStore() *SessionStore {
 	return &SessionStore{
-		Store: make(map[string]*Session),
+		Store:     make(map[string]*Session),
+		CodeQueue: &CodeQueue{},
 	}
 }
 
 // NewSession creates a new Session for a User
 func (ss *SessionStore) NewSession(scope string, state string, nonce string, user *User) (*Session, error) {
-	sessionID, err := randomNonce(24)
+	sessionID, err := ss.CodeQueue.Pop()
 	if err != nil {
 		return nil, err
 	}

--- a/user.go
+++ b/user.go
@@ -1,7 +1,5 @@
 package mockoidc
 
-import "sync"
-
 // User represents a mock user that the server will grant Oauth tokens for.
 // Calls to the `authorization_endpoint` will pop any mock Users added to the
 // `UserQueue`. Otherwise `DefaultUser()` is returned.
@@ -13,13 +11,6 @@ type User struct {
 	Phone             string   `json:"phone,omitempty"`
 	Address           string   `json:"address,omitempty"`
 	Groups            []string `json:"groups,omitempty"`
-}
-
-// UserQueue manages the queue of Users returned for each
-// call to the authorize endpoint
-type UserQueue struct {
-	sync.Mutex
-	Queue []*User
 }
 
 // DefaultUser returns a default User that is set in `authorization_endpoint`
@@ -34,28 +25,6 @@ func DefaultUser() *User {
 		Groups:            []string{"engineering", "design"},
 		EmailVerified:     true,
 	}
-}
-
-// Push adds a User to the Queue to be set in subsequent calls to the
-// `authorization_endpoint`
-func (q *UserQueue) Push(user *User) {
-	q.Lock()
-	defer q.Unlock()
-	q.Queue = append(q.Queue, user)
-}
-
-// Pop a User from the Queue. If empty, return `DefaultUser()`
-func (q *UserQueue) Pop() *User {
-	q.Lock()
-	defer q.Unlock()
-
-	if len(q.Queue) == 0 {
-		return DefaultUser()
-	}
-
-	var user *User
-	user, q.Queue = q.Queue[0], q.Queue[1:]
-	return user
 }
 
 func (u *User) populateClaims(scopes []string, claims *idTokenClaims) {


### PR DESCRIPTION
Have in code PrivateKey as `DefaultKeypair` to eliminate overhead of random key generation & allow consistent test results if desired.

Allow `authorization_endpoint` code responses to be preset in a queue using `MockOIDC.PushCode(code string)`.