### PR TITLE
Streamline Test Package & Add Full Integration Test

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -13,12 +13,12 @@ import (
 )
 
 const (
-	IssuerBase        = "/oidc"
-	AuthorizeEndpoint = "/oidc/authorize"
-	TokenEndpoint     = "/oidc/token"
-	UserinfoEndpoint  = "/oidc/userinfo"
-	JWKSEndpoint      = "/oidc/.well-known/jwks.json"
-	DiscoveryEndpoint = "/oidc/.well-known/openid-configuration"
+	IssuerBase            = "/oidc"
+	AuthorizationEndpoint = "/oidc/authorize"
+	TokenEndpoint         = "/oidc/token"
+	UserinfoEndpoint      = "/oidc/userinfo"
+	JWKSEndpoint          = "/oidc/.well-known/jwks.json"
+	DiscoveryEndpoint     = "/oidc/.well-known/openid-configuration"
 
 	InvalidRequest       = "invalid_request"
 	InvalidClient        = "invalid_client"
@@ -317,7 +317,7 @@ type discoveryResponse struct {
 func (m *MockOIDC) Discovery(rw http.ResponseWriter, _ *http.Request) {
 	discovery := &discoveryResponse{
 		Issuer:                m.Issuer(),
-		AuthorizationEndpoint: m.Issuer() + AuthorizeEndpoint,
+		AuthorizationEndpoint: m.Issuer() + AuthorizationEndpoint,
 		TokenEndpoint:         m.Issuer() + TokenEndpoint,
 		JWKSUri:               m.Issuer() + JWKSEndpoint,
 		UserinfoEndpoint:      m.Issuer() + UserinfoEndpoint,
@@ -388,11 +388,11 @@ func (m *MockOIDC) authorizeToken(t string, rw http.ResponseWriter) (*jwt.Token,
 }
 
 func assertPresence(params []string, rw http.ResponseWriter, req *http.Request) bool {
+	fmt.Printf("%v\n", req.Form)
 	for _, param := range params {
 		if req.Form.Get(param) != "" {
 			continue
 		}
-
 		errorResponse(
 			rw,
 			InvalidRequest,

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -25,18 +25,18 @@ func TestMockOIDC_Authorize(t *testing.T) {
 	data.Set("redirect_uri", "example.com")
 	data.Set("state", "testState")
 	data.Set("client_id", m.ClientID)
-	assert.HTTPError(t, m.Authorize, http.MethodGet, mockoidc.AuthorizeEndpoint, nil)
+	assert.HTTPError(t, m.Authorize, http.MethodGet, mockoidc.AuthorizationEndpoint, nil)
 
 	// valid request
 	assert.HTTPStatusCode(t, m.Authorize, http.MethodGet,
-		mockoidc.AuthorizeEndpoint, data, http.StatusFound)
+		mockoidc.AuthorizationEndpoint, data, http.StatusFound)
 
 	// Bad client ID
 	data.Set("client_id", "wrong_id")
 	assert.HTTPStatusCode(t, m.Authorize, http.MethodGet,
-		mockoidc.AuthorizeEndpoint, data, http.StatusUnauthorized)
+		mockoidc.AuthorizationEndpoint, data, http.StatusUnauthorized)
 	assert.HTTPBodyContains(t, m.Authorize, http.MethodGet,
-		mockoidc.AuthorizeEndpoint, data, mockoidc.InvalidClient)
+		mockoidc.AuthorizationEndpoint, data, mockoidc.InvalidClient)
 
 	// Missing required form values
 	for key := range data {
@@ -45,9 +45,9 @@ func TestMockOIDC_Authorize(t *testing.T) {
 			badData.Del(key)
 
 			assert.HTTPStatusCode(t, m.Authorize, http.MethodGet,
-				mockoidc.AuthorizeEndpoint, badData, http.StatusBadRequest)
+				mockoidc.AuthorizationEndpoint, badData, http.StatusBadRequest)
 			assert.HTTPBodyContains(t, m.Authorize, http.MethodGet,
-				mockoidc.AuthorizeEndpoint, badData, mockoidc.InvalidRequest)
+				mockoidc.AuthorizationEndpoint, badData, mockoidc.InvalidRequest)
 		})
 	}
 }
@@ -194,7 +194,7 @@ func TestMockOIDC_Discovery(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, oidcCfg["issuer"], m.Issuer())
-	assert.Equal(t, oidcCfg["authorization_endpoint"], m.Issuer()+mockoidc.AuthorizeEndpoint)
+	assert.Equal(t, oidcCfg["authorization_endpoint"], m.Issuer()+mockoidc.AuthorizationEndpoint)
 	assert.Equal(t, oidcCfg["token_endpoint"], m.Issuer()+mockoidc.TokenEndpoint)
 	assert.Equal(t, oidcCfg["userinfo_endpoint"], m.Issuer()+mockoidc.UserinfoEndpoint)
 	assert.Equal(t, oidcCfg["jwks_uri"], m.Issuer()+mockoidc.JWKSEndpoint)

--- a/mockoidc.go
+++ b/mockoidc.go
@@ -148,7 +148,7 @@ func (m *MockOIDC) Issuer() string {
 	if m.Server.TLSConfig != nil {
 		proto = "https"
 	}
-	return fmt.Sprintf("%s://%s%s", proto, m.Server.Addr, issuerBase)
+	return fmt.Sprintf("%s://%s%s", proto, m.Server.Addr, IssuerBase)
 }
 
 // QueueUser allows adding mock User objects to the authentication queue.

--- a/mockoidc.go
+++ b/mockoidc.go
@@ -100,11 +100,11 @@ func (m *MockOIDC) Start(ln net.Listener, cfg *tls.Config) error {
 	}
 
 	handler := http.NewServeMux()
-	handler.HandleFunc(authorizeEndpoint, m.Authorize)
-	handler.HandleFunc(tokenEndpoint, m.Token)
-	handler.HandleFunc(userinfoEndpoint, m.Userinfo)
-	handler.HandleFunc(jwksEndpoint, m.JWKS)
-	handler.HandleFunc(discoveryEndpoint, m.JWKS)
+	handler.HandleFunc(AuthorizeEndpoint, m.Authorize)
+	handler.HandleFunc(TokenEndpoint, m.Token)
+	handler.HandleFunc(UserinfoEndpoint, m.Userinfo)
+	handler.HandleFunc(JWKSEndpoint, m.JWKS)
+	handler.HandleFunc(DiscoveryEndpoint, m.JWKS)
 
 	m.Server = &http.Server{
 		Addr:      ln.Addr().String(),
@@ -148,7 +148,7 @@ func (m *MockOIDC) Issuer() string {
 	if m.Server.TLSConfig != nil {
 		proto = "https"
 	}
-	return fmt.Sprintf("%s://%s/", proto, m.Server.Addr)
+	return fmt.Sprintf("%s://%s%s", proto, m.Server.Addr, issuerBase)
 }
 
 // QueueUser allows adding mock User objects to the authentication queue.

--- a/mockoidc_test.go
+++ b/mockoidc_test.go
@@ -1,0 +1,233 @@
+package mockoidc_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/oauth2-proxy/mockoidc/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+// A custom client that doesn't automatically follow redirects
+var httpClient = &http.Client{
+	CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	},
+}
+
+func TestRun(t *testing.T) {
+	m, err := mockoidc.Run()
+	assert.NoError(t, err)
+	defer m.Shutdown()
+
+	// Override jwt.TimeFunc with our timer
+	m.Synchronize()
+
+	// ************************************************************************
+	// Stage 0: Get Discovery documents
+	// ************************************************************************
+	discoveryReq, err := http.NewRequest(http.MethodGet, m.DiscoveryEndpoint(), nil)
+	assert.NoError(t, err)
+
+	resp, err := httpClient.Do(discoveryReq)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	jwksReq, err := http.NewRequest(http.MethodGet, m.JWKSEndpoint(), nil)
+	assert.NoError(t, err)
+
+	resp, err = httpClient.Do(jwksReq)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	config := m.Config()
+
+	// ************************************************************************
+	// Stage 1: Emulate client to IdP request
+	// ************************************************************************
+	const (
+		state = "abcdef1234567890"
+		nonce = "0987654321fedcba"
+		code  = "asdflkjh12340987"
+	)
+	authorizeQuery := url.Values{}
+	authorizeQuery.Set("client_id", config.ClientID)
+	authorizeQuery.Set("scope", "openid email profile groups")
+	authorizeQuery.Set("response_type", "code")
+	authorizeQuery.Set("redirect_uri", "http://127.0.0.1/oauth2/callback")
+	authorizeQuery.Set("state", state)
+	authorizeQuery.Set("nonce", nonce)
+
+	authorizeURL, err := url.Parse(m.AuthorizationEndpoint())
+	assert.NoError(t, err)
+	authorizeURL.RawQuery = authorizeQuery.Encode()
+
+	authorizeReq, err := http.NewRequest(http.MethodGet, authorizeURL.String(), nil)
+	assert.NoError(t, err)
+
+	m.QueueCode(code)
+	resp, err = httpClient.Do(authorizeReq)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusFound, resp.StatusCode)
+
+	appRedirect, err := url.Parse(resp.Header.Get("Location"))
+	assert.NoError(t, err)
+	assert.Equal(t, code, appRedirect.Query().Get("code"))
+	assert.Equal(t, state, appRedirect.Query().Get("state"))
+
+	// ************************************************************************
+	// Stage 2: Emulate appRedirect handling token endpoint call
+	// ************************************************************************
+	tokenQuery := url.Values{}
+	tokenQuery.Set("grant_type", "authorization_code")
+	tokenQuery.Set("code", code)
+
+	tokenForm := url.Values{}
+	tokenForm.Set("client_id", config.ClientID)
+	tokenForm.Set("client_secret", config.ClientSecret)
+
+	tokenURL, err := url.Parse(m.TokenEndpoint())
+	assert.NoError(t, err)
+	tokenURL.RawQuery = tokenQuery.Encode()
+
+	tokenReq, err := http.NewRequest(
+		http.MethodPost, tokenURL.String(), bytes.NewBufferString(tokenForm.Encode()))
+	assert.NoError(t, err)
+	tokenReq.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err = httpClient.Do(tokenReq)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	assert.NoError(t, err)
+
+	tokens := make(map[string]interface{})
+	err = json.Unmarshal(body, &tokens)
+	assert.NoError(t, err)
+
+	_, err = m.Keypair.VerifyJWT(tokens["access_token"].(string))
+	assert.NoError(t, err)
+	_, err = m.Keypair.VerifyJWT(tokens["refresh_token"].(string))
+	assert.NoError(t, err)
+	idToken, err := m.Keypair.VerifyJWT(tokens["id_token"].(string))
+	assert.NoError(t, err)
+
+	// The nonce we set initially is in our ID Token
+	claims, ok := idToken.Claims.(jwt.MapClaims)
+	assert.True(t, ok)
+	assert.Equal(t, nonce, claims["nonce"])
+
+	// ************************************************************************
+	// Stage 3: Use the Access Token for a Userinfo call
+	// ************************************************************************
+	userinfoReq, err := http.NewRequest(http.MethodGet, m.UserinfoEndpoint(), nil)
+	assert.NoError(t, err)
+	userinfoReq.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tokens["id_token"]))
+
+	resp, err = httpClient.Do(userinfoReq)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// ************************************************************************
+	// Stage 4: Expired Tokens don't work
+	// ************************************************************************
+	m.FastForward(config.AccessTTL + 1)
+
+	expiredReq, err := http.NewRequest(http.MethodGet, m.UserinfoEndpoint(), nil)
+	assert.NoError(t, err)
+	userinfoReq.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tokens["id_token"]))
+
+	resp, err = httpClient.Do(expiredReq)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	// ************************************************************************
+	// Stage 5: We can refresh them
+	// ************************************************************************
+	refreshQuery := url.Values{}
+	refreshQuery.Set("grant_type", "refresh_token")
+	refreshQuery.Set("refresh_token", tokens["refresh_token"].(string))
+
+	refreshForm := url.Values{}
+	refreshForm.Set("client_id", config.ClientID)
+	refreshForm.Set("client_secret", config.ClientSecret)
+
+	refreshURL, err := url.Parse(m.TokenEndpoint())
+	assert.NoError(t, err)
+	refreshURL.RawQuery = refreshQuery.Encode()
+
+	refreshReq, err := http.NewRequest(
+		http.MethodPost, refreshURL.String(), bytes.NewBufferString(refreshForm.Encode()))
+	assert.NoError(t, err)
+	refreshReq.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err = httpClient.Do(refreshReq)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	defer resp.Body.Close()
+	refreshBody, err := ioutil.ReadAll(resp.Body)
+	assert.NoError(t, err)
+
+	refreshedTokens := make(map[string]interface{})
+	err = json.Unmarshal(refreshBody, &refreshedTokens)
+	assert.NoError(t, err)
+
+	_, err = m.Keypair.VerifyJWT(refreshedTokens["access_token"].(string))
+	assert.NoError(t, err)
+	_, err = m.Keypair.VerifyJWT(refreshedTokens["refresh_token"].(string))
+	assert.NoError(t, err)
+	refreshedIDToken, err := m.Keypair.VerifyJWT(refreshedTokens["id_token"].(string))
+	assert.NoError(t, err)
+
+	// The nonce we set initially is STILL in our ID Token
+	refreshedClaims, ok := refreshedIDToken.Claims.(jwt.MapClaims)
+	assert.True(t, ok)
+	assert.Equal(t, nonce, refreshedClaims["nonce"])
+
+	// ************************************************************************
+	// Stage 6: Access Token works again
+	// ************************************************************************
+	userinfoReq2, err := http.NewRequest(http.MethodGet, m.UserinfoEndpoint(), nil)
+	assert.NoError(t, err)
+	userinfoReq2.Header.Add("Authorization",
+		fmt.Sprintf("Bearer %s", refreshedTokens["id_token"]))
+
+	resp, err = httpClient.Do(userinfoReq2)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// ************************************************************************
+	// Stage 7: Refresh Tokens expire and won't refresh
+	// ************************************************************************
+	m.FastForward(config.RefreshTTL)
+
+	refreshQuery2 := url.Values{}
+	refreshQuery2.Set("grant_type", "refresh_token")
+	refreshQuery2.Set("refresh_token", tokens["refresh_token"].(string))
+
+	refreshForm2 := url.Values{}
+	refreshForm2.Set("client_id", config.ClientID)
+	refreshForm2.Set("client_secret", config.ClientSecret)
+
+	refreshURL2, err := url.Parse(m.TokenEndpoint())
+	assert.NoError(t, err)
+	refreshURL2.RawQuery = refreshQuery2.Encode()
+
+	refreshReq2, err := http.NewRequest(
+		http.MethodPost, refreshURL2.String(), bytes.NewBufferString(tokenForm.Encode()))
+	assert.NoError(t, err)
+	refreshReq2.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err = httpClient.Do(refreshReq2)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}


### PR DESCRIPTION
Moves all tests to the `mockoidc_test` package.

Runs the full OIDC login flow against a running server started with `mockoidc.Run`.

It's a little gnarly at the moment, but it touches every aspect of the login flow. We can break it up if desired later.