### PR TITLE
Fix discovery URLs

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -320,10 +320,10 @@ type discoveryResponse struct {
 func (m *MockOIDC) Discovery(rw http.ResponseWriter, _ *http.Request) {
 	discovery := &discoveryResponse{
 		Issuer:                m.Issuer(),
-		AuthorizationEndpoint: m.Issuer() + AuthorizationEndpoint,
-		TokenEndpoint:         m.Issuer() + TokenEndpoint,
-		JWKSUri:               m.Issuer() + JWKSEndpoint,
-		UserinfoEndpoint:      m.Issuer() + UserinfoEndpoint,
+		AuthorizationEndpoint: m.AuthorizationEndpoint(),
+		TokenEndpoint:         m.TokenEndpoint(),
+		JWKSUri:               m.JWKSEndpoint(),
+		UserinfoEndpoint:      m.UserinfoEndpoint(),
 
 		GrantTypesSupported:               GrantTypesSupported,
 		ResponseTypesSupported:            ResponseTypesSupported,

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -198,10 +198,10 @@ func TestMockOIDC_Discovery(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, oidcCfg["issuer"], m.Issuer())
-	assert.Equal(t, oidcCfg["authorization_endpoint"], m.Issuer()+mockoidc.AuthorizationEndpoint)
-	assert.Equal(t, oidcCfg["token_endpoint"], m.Issuer()+mockoidc.TokenEndpoint)
-	assert.Equal(t, oidcCfg["userinfo_endpoint"], m.Issuer()+mockoidc.UserinfoEndpoint)
-	assert.Equal(t, oidcCfg["jwks_uri"], m.Issuer()+mockoidc.JWKSEndpoint)
+	assert.Equal(t, oidcCfg["authorization_endpoint"], m.AuthorizationEndpoint())
+	assert.Equal(t, oidcCfg["token_endpoint"], m.TokenEndpoint())
+	assert.Equal(t, oidcCfg["userinfo_endpoint"], m.UserinfoEndpoint())
+	assert.Equal(t, oidcCfg["jwks_uri"], m.JWKSEndpoint())
 }
 
 func getJSON(res *httptest.ResponseRecorder, target interface{}) error {


### PR DESCRIPTION
Fix discovery URLs that were not reachable due to a duplication of `/oidc` when using `m.Issuer` as URL prefix