### PR TITLE
Support PKCE Code Challenge

### DIFF
--- a/encryption.go
+++ b/encryption.go
@@ -4,13 +4,20 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/golang-jwt/jwt"
 	"gopkg.in/square/go-jose.v2"
+)
+
+const (
+	CodeChallengeMethodPlain = "plain"
+	CodeChallengeMethodS256  = "S256"
 )
 
 const DefaultKey = `MIIEowIBAAKCAQEAtI1Jf2zmfwLzpAjVarORtjKtmCHQtgNxqWDdVNVa` +
@@ -165,4 +172,16 @@ func randomNonce(length int) (string, error) {
 		return "", err
 	}
 	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+func GenerateCodeChallenge(method, codeVerifier string) (string, error) {
+	switch method {
+	case CodeChallengeMethodPlain:
+		return codeVerifier, nil
+	case CodeChallengeMethodS256:
+		shaSum := sha256.Sum256([]byte(codeVerifier))
+		return base64.RawURLEncoding.EncodeToString(shaSum[:]), nil
+	default:
+		return "", fmt.Errorf("unknown challenge method: %v", method)
+	}
 }

--- a/handlers.go
+++ b/handlers.go
@@ -167,7 +167,7 @@ func (m *MockOIDC) Token(rw http.ResponseWriter, req *http.Request) {
 			return
 		}
 
-		if valid = m.validateCodeChallenge(rw, req, session); !valid {
+		if !m.validateCodeChallenge(rw, req, session) {
 			return
 		}
 	case "refresh_token":

--- a/mockoidc.go
+++ b/mockoidc.go
@@ -26,6 +26,8 @@ type MockOIDC struct {
 	AccessTTL  time.Duration
 	RefreshTTL time.Duration
 
+	CodeChallengeMethodsSupported []string
+
 	// Normally, these would be private. Expose them publicly for
 	// power users.
 	Server       *http.Server
@@ -48,6 +50,8 @@ type Config struct {
 
 	AccessTTL  time.Duration
 	RefreshTTL time.Duration
+
+	CodeChallengeMethodsSupported []string
 }
 
 // NewServer configures a new MockOIDC that isn't started. An existing
@@ -68,14 +72,15 @@ func NewServer(key *rsa.PrivateKey) (*MockOIDC, error) {
 	}
 
 	return &MockOIDC{
-		ClientID:     clientID,
-		ClientSecret: clientSecret,
-		AccessTTL:    time.Duration(10) * time.Minute,
-		RefreshTTL:   time.Duration(60) * time.Minute,
-		Keypair:      keypair,
-		SessionStore: NewSessionStore(),
-		UserQueue:    &UserQueue{},
-		ErrorQueue:   &ErrorQueue{},
+		ClientID:                      clientID,
+		ClientSecret:                  clientSecret,
+		AccessTTL:                     time.Duration(10) * time.Minute,
+		RefreshTTL:                    time.Duration(60) * time.Minute,
+		CodeChallengeMethodsSupported: []string{"plain", "S256"},
+		Keypair:                       keypair,
+		SessionStore:                  NewSessionStore(),
+		UserQueue:                     &UserQueue{},
+		ErrorQueue:                    &ErrorQueue{},
 	}, nil
 }
 
@@ -148,11 +153,12 @@ func (m *MockOIDC) AddMiddleware(mw func(http.Handler) http.Handler) error {
 // tests need to be aware of.
 func (m *MockOIDC) Config() *Config {
 	return &Config{
-		ClientID:     m.ClientID,
-		ClientSecret: m.ClientSecret,
-		Issuer:       m.Issuer(),
-		AccessTTL:    m.AccessTTL,
-		RefreshTTL:   m.RefreshTTL,
+		ClientID:                      m.ClientID,
+		ClientSecret:                  m.ClientSecret,
+		Issuer:                        m.Issuer(),
+		CodeChallengeMethodsSupported: m.CodeChallengeMethodsSupported,
+		AccessTTL:                     m.AccessTTL,
+		RefreshTTL:                    m.RefreshTTL,
 	}
 }
 

--- a/mockoidc_test.go
+++ b/mockoidc_test.go
@@ -72,6 +72,12 @@ func TestRun(t *testing.T) {
 	authorizeQuery.Set("state", state)
 	authorizeQuery.Set("nonce", nonce)
 
+	codeVerifier := "sum"
+	challenge, err := mockoidc.GenerateCodeChallenge(mockoidc.CodeChallengeMethodS256, codeVerifier)
+	assert.NoError(t, err)
+	authorizeQuery.Set("code_challenge", challenge)
+	authorizeQuery.Set("code_challenge_method", mockoidc.CodeChallengeMethodS256)
+
 	authorizeURL, err := url.Parse(m.AuthorizationEndpoint())
 	assert.NoError(t, err)
 	authorizeURL.RawQuery = authorizeQuery.Encode()
@@ -97,6 +103,7 @@ func TestRun(t *testing.T) {
 	tokenForm.Set("client_secret", config.ClientSecret)
 	tokenForm.Set("grant_type", "authorization_code")
 	tokenForm.Set("code", appRedirect.Query().Get("code"))
+	tokenForm.Set("code_verifier", codeVerifier)
 
 	tokenReq, err := http.NewRequest(
 		http.MethodPost, m.TokenEndpoint(), bytes.NewBufferString(tokenForm.Encode()))
@@ -233,6 +240,7 @@ func TestMockOIDC_Config(t *testing.T) {
 	assert.Equal(t, m.Issuer(), cfg.Issuer)
 	assert.Equal(t, m.AccessTTL, cfg.AccessTTL)
 	assert.Equal(t, m.RefreshTTL, cfg.RefreshTTL)
+	assert.Equal(t, m.CodeChallengeMethodsSupported, cfg.CodeChallengeMethodsSupported)
 }
 
 func TestMockOIDC_QueueError(t *testing.T) {

--- a/session.go
+++ b/session.go
@@ -10,11 +10,13 @@ import (
 
 // Session stores a User and their OIDC options across requests
 type Session struct {
-	SessionID string
-	Scopes    []string
-	OIDCNonce string
-	User      User
-	Granted   bool
+	SessionID           string
+	Scopes              []string
+	OIDCNonce           string
+	User                User
+	Granted             bool
+	CodeChallenge       string
+	CodeChallengeMethod string
 }
 
 // SessionStore manages our Session objects
@@ -39,17 +41,19 @@ func NewSessionStore() *SessionStore {
 }
 
 // NewSession creates a new Session for a User
-func (ss *SessionStore) NewSession(scope string, nonce string, user User) (*Session, error) {
+func (ss *SessionStore) NewSession(scope string, nonce string, user User, codeChallenge string, codeChallengeMethod string) (*Session, error) {
 	sessionID, err := ss.CodeQueue.Pop()
 	if err != nil {
 		return nil, err
 	}
 
 	session := &Session{
-		SessionID: sessionID,
-		Scopes:    strings.Split(scope, " "),
-		OIDCNonce: nonce,
-		User:      user,
+		SessionID:           sessionID,
+		Scopes:              strings.Split(scope, " "),
+		OIDCNonce:           nonce,
+		User:                user,
+		CodeChallenge:       codeChallenge,
+		CodeChallengeMethod: codeChallengeMethod,
 	}
 	ss.Store[sessionID] = session
 

--- a/session_test.go
+++ b/session_test.go
@@ -38,12 +38,14 @@ func TestSessionStore_NewSession(t *testing.T) {
 	)
 	user := mockoidc.DefaultUser()
 
-	session, err := ss.NewSession(scope, oidcNonce, user)
+	session, err := ss.NewSession(scope, oidcNonce, user, "sum", "S256")
 
 	assert.NoError(t, err)
 	assert.Equal(t, session.Scopes, []string{"openid", "email", "profile"})
 	assert.Equal(t, len(ss.Store), 1)
 	assert.Equal(t, ss.Store[session.SessionID], session)
+	assert.Equal(t, session.CodeChallenge, "sum")
+	assert.Equal(t, session.CodeChallengeMethod, "S256")
 }
 
 func TestSession_AccessToken(t *testing.T) {
@@ -120,7 +122,7 @@ func TestSessionStore_GetSessionByID(t *testing.T) {
 		oidcNonce = "nonce"
 	)
 	user := mockoidc.DefaultUser()
-	_, err := ss.NewSession(scope, oidcNonce, user)
+	_, err := ss.NewSession(scope, oidcNonce, user, "sum", "S256")
 	assert.NoError(t, err)
 
 	user2 := &mockoidc.MockUser{
@@ -132,7 +134,7 @@ func TestSessionStore_GetSessionByID(t *testing.T) {
 		Groups:            []string{"another", "different"},
 		EmailVerified:     true,
 	}
-	s2, err := ss.NewSession(scope, oidcNonce, user2)
+	s2, err := ss.NewSession(scope, oidcNonce, user2, "", "")
 	assert.NoError(t, err)
 
 	session, err := ss.GetSessionByID(s2.SessionID)
@@ -152,7 +154,7 @@ func TestSessionStore_GetSessionFromToken(t *testing.T) {
 		oidcNonce = "nonce"
 	)
 	user := mockoidc.DefaultUser()
-	_, err := ss.NewSession(scope, oidcNonce, user)
+	_, err := ss.NewSession(scope, oidcNonce, user, "sum", "S256")
 	assert.NoError(t, err)
 
 	user2 := &mockoidc.MockUser{
@@ -164,7 +166,7 @@ func TestSessionStore_GetSessionFromToken(t *testing.T) {
 		Groups:            []string{"another", "different"},
 		EmailVerified:     true,
 	}
-	s2, err := ss.NewSession(scope, oidcNonce, user2)
+	s2, err := ss.NewSession(scope, oidcNonce, user2, "sum", "S256")
 	assert.NoError(t, err)
 
 	keypair, err := mockoidc.DefaultKeypair()


### PR DESCRIPTION
- Adds suppoprt for 'plain' and 'S256' code challenge methods
- Adds partial support for the authorization server metadata in the discovery document
for the supported code challenge types

Fixes #23