### PR TITLE
feat: Add possibility to override base Issuer

### DIFF
--- a/mockoidc.go
+++ b/mockoidc.go
@@ -23,6 +23,8 @@ type MockOIDC struct {
 	ClientID     string
 	ClientSecret string
 
+	IssuerBaseUrl string
+
 	AccessTTL  time.Duration
 	RefreshTTL time.Duration
 
@@ -225,7 +227,14 @@ func (m *MockOIDC) Issuer() string {
 	if m.Server == nil {
 		return ""
 	}
+
+	// Generate the Issue from IssuerBaseUrl and the root path /oidc
+	if m.IssuerBaseUrl != "" {
+		return m.IssuerBaseUrl + IssuerBase
+	}
+
 	return m.Addr() + IssuerBase
+
 }
 
 // DiscoveryEndpoint returns the full `/.well-known/openid-configuration` URL
@@ -233,6 +242,12 @@ func (m *MockOIDC) DiscoveryEndpoint() string {
 	if m.Server == nil {
 		return ""
 	}
+
+	// Generate the Issue from IssuerBaseUrl
+	if m.IssuerBaseUrl != "" {
+		return m.IssuerBaseUrl + DiscoveryEndpoint
+	}
+
 	return m.Addr() + DiscoveryEndpoint
 }
 
@@ -241,6 +256,12 @@ func (m *MockOIDC) AuthorizationEndpoint() string {
 	if m.Server == nil {
 		return ""
 	}
+
+	// Generate the Issue from IssuerBaseUrl
+	if m.IssuerBaseUrl != "" {
+		return m.IssuerBaseUrl + AuthorizationEndpoint
+	}
+
 	return m.Addr() + AuthorizationEndpoint
 }
 
@@ -249,6 +270,12 @@ func (m *MockOIDC) TokenEndpoint() string {
 	if m.Server == nil {
 		return ""
 	}
+
+	// Generate the Issue from IssuerBaseUrl
+	if m.IssuerBaseUrl != "" {
+		return m.IssuerBaseUrl + TokenEndpoint
+	}
+
 	return m.Addr() + TokenEndpoint
 }
 
@@ -257,6 +284,12 @@ func (m *MockOIDC) UserinfoEndpoint() string {
 	if m.Server == nil {
 		return ""
 	}
+
+	// Generate the Issue from IssuerBaseUrl
+	if m.IssuerBaseUrl != "" {
+		return m.IssuerBaseUrl + UserinfoEndpoint
+	}
+
 	return m.Addr() + UserinfoEndpoint
 }
 
@@ -265,6 +298,12 @@ func (m *MockOIDC) JWKSEndpoint() string {
 	if m.Server == nil {
 		return ""
 	}
+
+	// Generate the Issue from IssuerBaseUrl
+	if m.IssuerBaseUrl != "" {
+		return m.IssuerBaseUrl + JWKSEndpoint
+	}
+
 	return m.Addr() + JWKSEndpoint
 }
 

--- a/mockoidc_test.go
+++ b/mockoidc_test.go
@@ -243,6 +243,22 @@ func TestMockOIDC_Config(t *testing.T) {
 	assert.Equal(t, m.CodeChallengeMethodsSupported, cfg.CodeChallengeMethodsSupported)
 }
 
+func TestMockOIDC_ConfigBaseIssuer(t *testing.T) {
+	m, err := mockoidc.Run()
+	assert.NoError(t, err)
+	defer m.Shutdown()
+
+	m.IssuerBaseUrl = "https://idp.oidc.proxy.com"
+
+	cfg := m.Config()
+	assert.Equal(t, m.ClientID, cfg.ClientID)
+	assert.Equal(t, m.ClientSecret, cfg.ClientSecret)
+	assert.Equal(t, m.Issuer(), cfg.Issuer)
+	assert.Equal(t, m.AccessTTL, cfg.AccessTTL)
+	assert.Equal(t, m.RefreshTTL, cfg.RefreshTTL)
+	assert.Equal(t, m.CodeChallengeMethodsSupported, cfg.CodeChallengeMethodsSupported)
+}
+
 func TestMockOIDC_QueueError(t *testing.T) {
 	m, err := mockoidc.Run()
 	assert.NoError(t, err)


### PR DESCRIPTION
Add a `IssuerBaseUrl` string that can be used to specify the base url to reach the mockoidc server.

Then if the `IssuerBaseUrl != ""` use it to generate the Urls, otherwise default to use  `m.Addr()` for backward compatibility


Fixes: #34