### PR TITLE
Fix expires_in in OAuth2 Token is too huge

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -180,7 +180,8 @@ func (m *MockOIDC) Token(rw http.ResponseWriter, req *http.Request) {
 	tr := &tokenResponse{
 		RefreshToken: req.Form.Get("refresh_token"),
 		TokenType:    "bearer",
-		ExpiresIn:    m.AccessTTL,
+		// expires_in in OAuth2 Token is the lifetime in seconds of the access token
+		ExpiresIn: m.AccessTTL / time.Second,
 	}
 	err = m.setTokens(tr, session, grantType)
 	if err != nil {


### PR DESCRIPTION
According to RFC6749, `expires_in` in OAuth2 Token is the lifetime in seconds of the access token.

- https://www.rfc-editor.org/rfc/rfc6749#section-4.2.2

But mockoidc set MockOIDC.AccessTTL directly to expires_in, making `expires_in` huge; e.g. if AccessTTL = 10 * time.Seconds (1000000000), `expires_in` becomes 10000000000 in seconds.

Fix it.

Signed-off-by: Naoto Kobayashi <naoto.kobayashi4c@gmail.com>