### PR TITLE
Allow overriding the default user that is returned when the queue is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ cfg := m.Config()
 //   	ClientID     string
 //   	ClientSecret string
 //   	Issuer       string
-//   
+//
 //   	AccessTTL  time.Duration
 //   	RefreshTTL time.Duration
 // }
@@ -95,6 +95,15 @@ m.QueueUser(user)
 m.QueueCode("12345")
 
 // ...Request to m.AuthorizationEndpoint()
+```
+
+You can also override the default user that is returned:
+
+```
+user := &mockoidc.User{
+    // User details...
+}
+m.SetDefaultUser(user)
 ```
 
 ### Forcing Errors

--- a/mockoidc.go
+++ b/mockoidc.go
@@ -79,7 +79,7 @@ func NewServer(key *rsa.PrivateKey) (*MockOIDC, error) {
 		CodeChallengeMethodsSupported: []string{"plain", "S256"},
 		Keypair:                       keypair,
 		SessionStore:                  NewSessionStore(),
-		UserQueue:                     &UserQueue{},
+		UserQueue:                     &UserQueue{DefaultUser: DefaultUser()},
 		ErrorQueue:                    &ErrorQueue{},
 	}, nil
 }
@@ -167,6 +167,14 @@ func (m *MockOIDC) Config() *Config {
 // off the queue and create a session with them.
 func (m *MockOIDC) QueueUser(user User) {
 	m.UserQueue.Push(user)
+}
+
+// SetDefaultUser allows setting the default mock User object to return for
+// authentication when the authentication queue is empty.
+// Calls to the `authorization_endpoint` will return the set user instead of
+// `DefaultUser()` when the queue is empty.
+func (m *MockOIDC) SetDefaultUser(user User) {
+	m.UserQueue.SetDefaultUser(user)
 }
 
 // QueueCode allows adding mock code strings to the authentication queue.

--- a/queue.go
+++ b/queue.go
@@ -7,6 +7,8 @@ import "sync"
 type UserQueue struct {
 	sync.Mutex
 	Queue []User
+
+	DefaultUser User
 }
 
 // CodeQueue manages the queue of codes returned for each
@@ -37,18 +39,26 @@ func (q *UserQueue) Push(user User) {
 	q.Queue = append(q.Queue, user)
 }
 
-// Pop a User from the Queue. If empty, return `DefaultUser()`
+// Pop a User from the Queue. If empty, return `q.DefaultUser` if set, otherwise
+// `DefaultUser()`
 func (q *UserQueue) Pop() User {
 	q.Lock()
 	defer q.Unlock()
 
-	if len(q.Queue) == 0 {
+	if len(q.Queue) == 0 && q.DefaultUser != nil {
+		return q.DefaultUser
+	} else if len(q.Queue) == 0 {
 		return DefaultUser()
 	}
 
 	var user User
 	user, q.Queue = q.Queue[0], q.Queue[1:]
 	return user
+}
+
+// SetDefaultUser configures the queue with the default user to return when empty.
+func (q *UserQueue) SetDefaultUser(user User) {
+	q.DefaultUser = user
 }
 
 // Push adds a code to the Queue to be returned by subsequent


### PR DESCRIPTION
In using `mockoidc` with browser based testing scenarios for my web app, and I noticed that I don't have a lot of control/stability over how many times the OIDC IdP login flow gets invoked. So I'm finding myself resorting to have `mockoidc` returning the same user. Ideally, I can use the default user, but since I am only integrating with one OIDC provider (Azure AD B2C), the expected ID Token claims format doesn't match.

To address these two issues, I've been simply packing the queue an arbitrary number of times with the same user, but it would be great if I can just override the default user that is returned.

This PR adds a `SetDefaultUser` function that does just that.