### PR TITLE
Ignore ordering of openid token in scope parameter

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -295,10 +295,13 @@ func (m *MockOIDC) setTokens(tr *tokenResponse, s *Session, grantType string) er
 	if err != nil {
 		return err
 	}
-	if len(s.Scopes) > 0 && s.Scopes[0] == openidScope {
-		tr.IDToken, err = s.IDToken(m.Config(), m.Keypair, m.Now())
-		if err != nil {
-			return err
+	for _, scope := range s.Scopes {
+		if scope == openidScope {
+			tr.IDToken, err = s.IDToken(m.Config(), m.Keypair, m.Now())
+			if err != nil {
+				return err
+			}
+			break
 		}
 	}
 	if grantType != "refresh_token" {

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -71,8 +71,11 @@ func TestMockOIDC_Token_CodeGrant(t *testing.T) {
 	m, err := mockoidc.NewServer(nil)
 	assert.NoError(t, err)
 
+	// Note: we're setting openid to the end of the scope list to test
+	// that ordering is not considered when checking for "openid" in the
+	// list
 	session, _ := m.SessionStore.NewSession(
-		"openid email profile", "nonce", mockoidc.DefaultUser(), "", "")
+		"email profile openid", "nonce", mockoidc.DefaultUser(), "", "")
 
 	assert.HTTPError(t, m.Token, http.MethodPost, mockoidc.TokenEndpoint, nil)
 


### PR DESCRIPTION
Change the logic that checks for the "openid" token in the "scope" parameter value to ignore ordering.  The Scopes section of the specification appears to only require that "openid" be present in the list, not that it be the first item in the list:

OpenID Connect Basic Client Implementer's Guide 1.0 - draft 47

2.4. Scope Values

https://openid.net/specs/openid-connect-basic-1_0.html#Scopes